### PR TITLE
Prevent re-encoding

### DIFF
--- a/src/sponskrub/ffwrap.d
+++ b/src/sponskrub/ffwrap.d
@@ -65,7 +65,7 @@ bool add_ffmpeg_metadata(string input_filename, string output_filename, string m
 	}
 	write_metadata(metadata_filename, metadata);
 	
-	auto ffmpeg_process = spawnProcess(["ffmpeg", "-i", input_filename, "-i", metadata_filename, "-map_metadata", "0", "-map_chapters", "1", "-vcodec", "copy", output_filename]);
+	auto ffmpeg_process = spawnProcess(["ffmpeg", "-i", input_filename, "-i", metadata_filename, "-map_metadata", "0", "-map_chapters", "1", "-codec", "copy", output_filename]);
 	auto result = wait(ffmpeg_process) == 0;
 	
 	return result;


### PR DESCRIPTION
Pass `-codec copy` to ffmpeg in order to prevent re-encoding of audio tracks