### PR TITLE
Ensure all streams are copied

### DIFF
--- a/src/sponskrub/ffwrap.d
+++ b/src/sponskrub/ffwrap.d
@@ -91,7 +91,7 @@ bool add_ffmpeg_metadata(string input_filename, string output_filename, string m
 	}
 	write_metadata(metadata_filename, metadata);
 	
-	auto ffmpeg_process = spawnProcess(["ffmpeg", "-loglevel", "warning", "-hide_banner", "-stats", "-i", input_filename, "-i", metadata_filename, "-map_metadata", "0", "-map_chapters", "1", "-codec", "copy", output_filename]);
+	auto ffmpeg_process = spawnProcess(["ffmpeg", "-loglevel", "warning", "-hide_banner", "-stats", "-i", input_filename, "-i", metadata_filename, "-map", "0", "-map_metadata", "0", "-map_chapters", "1", "-codec", "copy", output_filename]);
 	auto result = wait(ffmpeg_process) == 0;
 	
 	return result;


### PR DESCRIPTION
When only `-c copy` is passed to ffmpeg without `-map 0`, only the first stream of each type is copied. So multiple audio/subs are lost.

See https://github.com/blackjack4494/yt-dlc/issues/193 and https://github.com/blackjack4494/yt-dlc/pull/205